### PR TITLE
expand section!() in #[test_case]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
+        args: --workspace
 
     - name: Install cargo-tarpaulin
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
 name = "rye-macros"
 version = "0.0.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -9,5 +9,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = "1"
+syn = { version = "1", features = [ "visit-mut" ] }
 quote = "1"
+proc-macro2 = "1"

--- a/macros/src/args.rs
+++ b/macros/src/args.rs
@@ -1,0 +1,18 @@
+use syn::{
+    parse::{Parse, ParseStream, Result},
+    punctuated::Punctuated,
+    MetaNameValue,
+};
+
+pub(crate) struct Args {
+    pub(crate) values: Vec<MetaNameValue>,
+}
+
+impl Parse for Args {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let values = Punctuated::<MetaNameValue, syn::Token![,]>::parse_terminated(input)?;
+        Ok(Self {
+            values: values.into_iter().collect(),
+        })
+    }
+}

--- a/macros/src/expand.rs
+++ b/macros/src/expand.rs
@@ -1,0 +1,89 @@
+use std::{
+    mem,
+    panic::{catch_unwind, resume_unwind, AssertUnwindSafe},
+};
+use syn::{
+    parse::{Error, Parse, ParseStream, Result},
+    visit_mut::{self, VisitMut},
+    Block, Expr, Macro, Stmt, Token,
+};
+
+struct SectionBody {
+    name: Expr,
+    _comma: Token![,],
+    block: Box<Block>,
+}
+
+impl Parse for SectionBody {
+    fn parse(input: ParseStream) -> Result<Self> {
+        Ok(Self {
+            name: input.parse()?,
+            _comma: input.parse()?,
+            block: input.parse()?,
+        })
+    }
+}
+
+struct ExpandBlock {
+    last_error: Option<Error>,
+}
+
+impl ExpandBlock {
+    fn throw_err(&mut self, err: Error) -> ! {
+        self.last_error.replace(err);
+        panic!("explicit panic");
+    }
+
+    fn expand_section_macro(&mut self, mac: &Macro) -> Stmt {
+        let body: SectionBody = match mac.parse_body() {
+            Ok(body) => body,
+            Err(err) => self.throw_err(err),
+        };
+
+        let name = &body.name;
+        let block = &body.block;
+
+        syn::parse_quote! {{
+            static SECTION: rye::_internal::SectionId = rye::_internal::SectionId::SubSection {
+                name: #name,
+                file: file!(),
+                line: line!(),
+                column: column!(),
+            };
+            if let Some(section) = rye::_internal::new_section(&SECTION) {
+                let _guard = rye::_internal::Guard::set(Some(Box::new(section)));
+                #block
+            }
+        }}
+    }
+
+    fn expand(&mut self, block: &mut syn::Block) -> Result<()> {
+        if let Err(payload) = catch_unwind(AssertUnwindSafe(|| self.visit_block_mut(block))) {
+            if let Some(err) = self.last_error.take() {
+                return Err(err);
+            }
+            resume_unwind(payload);
+        }
+        Ok(())
+    }
+}
+
+impl VisitMut for ExpandBlock {
+    fn visit_stmt_mut(&mut self, item: &mut Stmt) {
+        match item {
+            Stmt::Expr(Expr::Macro(expr_macro)) | Stmt::Semi(Expr::Macro(expr_macro), _) => {
+                if expr_macro.mac.path.is_ident("section") {
+                    let expanded = self.expand_section_macro(&expr_macro.mac);
+                    mem::replace(item, expanded);
+                }
+            }
+            _ => (),
+        }
+        visit_mut::visit_stmt_mut(self, item);
+    }
+}
+
+#[inline]
+pub(crate) fn expand(block: &mut Block) -> Result<()> {
+    ExpandBlock { last_error: None }.expand(block)
+}

--- a/macros/src/generate.rs
+++ b/macros/src/generate.rs
@@ -1,0 +1,63 @@
+use crate::args::Args;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::ItemFn;
+
+pub(crate) fn generate(args: Args, item: ItemFn) -> TokenStream {
+    let vis = &item.vis;
+    let fn_token = &item.sig.fn_token;
+    let ident = &item.sig.ident;
+    let output = &item.sig.output;
+    let block = &*item.block;
+
+    let test_attr: syn::Attribute = syn::parse_quote!(#[test]);
+    let attrs = Some(&test_attr).into_iter().chain(&item.attrs);
+
+    let body = match item.sig.asyncness {
+        Some(ref async_token) => {
+            let block_on: syn::Path = match args
+                .values
+                .iter()
+                .find(|value| value.path.is_ident("block_on"))
+            {
+                Some(value) => match &value.lit {
+                    syn::Lit::Str(lit_str) => match lit_str.parse() {
+                        Ok(path) => path,
+                        Err(err) => return err.to_compile_error().into(),
+                    },
+                    lit => {
+                        use syn::spanned::Spanned;
+                        let span = lit.span();
+                        return quote::quote_spanned!(span => const _: () = compile_error!("should be a string literal");)
+                            .into();
+                    }
+                },
+                None => syn::parse_quote!(block_on),
+            };
+
+            quote! {
+                #async_token #fn_token __inner__() #output #block
+                #block_on(async {
+                    let mut test_case = rye::TestCase::new();
+                    while !test_case.completed() {
+                        test_case.run_async(__inner__()).await;
+                    }
+                });
+            }
+        }
+        None => quote! {
+            #fn_token __inner__() #output #block
+            let mut test_case = rye::TestCase::new();
+            while !test_case.completed() {
+                test_case.run(__inner__);
+            }
+        },
+    };
+
+    quote! {
+        #(#attrs)*
+        #vis #fn_token #ident () {
+            #body
+        }
+    }
+}

--- a/macros/src/imp.rs
+++ b/macros/src/imp.rs
@@ -1,0 +1,268 @@
+use crate::args::Args;
+use proc_macro2::TokenStream;
+use syn::{parse::Result, ItemFn};
+
+pub(crate) fn test_case(args: TokenStream, item: TokenStream) -> Result<TokenStream> {
+    let args: Args = syn::parse2(args)?;
+
+    let mut item: ItemFn = syn::parse2(item)?;
+
+    crate::expand::expand(&mut *item.block)?;
+
+    Ok(crate::generate::generate(args, item))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::quote;
+
+    #[test]
+    fn test_sync() {
+        let args = TokenStream::new();
+        let item = quote! {
+            fn case_sync() {
+                let mut vec = vec![0usize; 5];
+                assert_eq!(vec.len(), 5);
+                assert!(vec.capacity() >= 5);
+
+                section!("resizing bigger changes size and capacity", {
+                    vec.resize(10, 0);
+                    assert_eq!(vec.len(), 10);
+                    assert!(vec.capacity() >= 5);
+                });
+            }
+        };
+        let expected = quote! {
+            #[test]
+            fn case_sync() {
+                fn __inner__() {
+                    let mut vec = vec![0usize; 5];
+                    assert_eq!(vec.len(), 5);
+                    assert!(vec.capacity() >= 5);
+
+                    {
+                        static SECTION: rye::_internal::SectionId = rye::_internal::SectionId::SubSection {
+                            name: "resizing bigger changes size and capacity",
+                            file: file!(),
+                            line: line!(),
+                            column: column!(),
+                        };
+
+                        if let Some(section) = rye::_internal::new_section(&SECTION) {
+                            let _guard = rye::_internal::Guard::set(Some(Box::new(section)));
+
+                            {
+                                vec.resize(10, 0);
+                                assert_eq!(vec.len(), 10);
+                                assert!(vec.capacity() >= 5);
+                            }
+                        }
+                    }
+                }
+
+                let mut test_case = rye::TestCase::new();
+                while !test_case.completed() {
+                    test_case.run(__inner__);
+                }
+            }
+        };
+
+        let output = test_case(args, item).unwrap();
+        assert_eq!(output.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_nested() {
+        let args = TokenStream::new();
+        let item = quote! {
+            fn case_sync() {
+                let mut vec = vec![0usize; 5];
+                assert_eq!(vec.len(), 5);
+                assert!(vec.capacity() >= 5);
+
+                section!("resizing bigger changes size and capacity", {
+                    vec.resize(10, 0);
+                    assert_eq!(vec.len(), 10);
+                    assert!(vec.capacity() >= 10);
+
+                    section!("shrinking smaller does not changes capacity", {
+                        vec.resize(0, 0);
+                        assert_eq!(vec.len(), 0);
+                        assert!(vec.capacity() >= 10);
+                    });
+                });
+            }
+        };
+        let expected = quote! {
+            #[test]
+            fn case_sync() {
+                fn __inner__() {
+                    let mut vec = vec![0usize; 5];
+                    assert_eq!(vec.len(), 5);
+                    assert!(vec.capacity() >= 5);
+
+                    {
+                        static SECTION: rye::_internal::SectionId = rye::_internal::SectionId::SubSection {
+                            name: "resizing bigger changes size and capacity",
+                            file: file!(),
+                            line: line!(),
+                            column: column!(),
+                        };
+
+                        if let Some(section) = rye::_internal::new_section(&SECTION) {
+                            let _guard = rye::_internal::Guard::set(Some(Box::new(section)));
+
+                            {
+                                vec.resize(10, 0);
+                                assert_eq!(vec.len(), 10);
+                                assert!(vec.capacity() >= 10);
+
+                                {
+                                    static SECTION: rye::_internal::SectionId = rye::_internal::SectionId::SubSection {
+                                        name: "shrinking smaller does not changes capacity",
+                                        file: file!(),
+                                        line: line!(),
+                                        column: column!(),
+                                    };
+
+                                    if let Some(section) = rye::_internal::new_section(&SECTION) {
+                                        let _guard = rye::_internal::Guard::set(Some(Box::new(section)));
+
+                                        {
+                                            vec.resize(0, 0);
+                                            assert_eq!(vec.len(), 0);
+                                            assert!(vec.capacity() >= 10);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                let mut test_case = rye::TestCase::new();
+                while !test_case.completed() {
+                    test_case.run(__inner__);
+                }
+            }
+        };
+
+        let output = test_case(args, item).unwrap();
+        assert_eq!(output.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_async() {
+        let args = TokenStream::new();
+        let item = quote! {
+            async fn case_async() {
+                let mut vec = vec![0usize; 5];
+                assert_eq!(vec.len(), 5);
+                assert!(vec.capacity() >= 5);
+
+                section!("resizing bigger changes size and capacity", {
+                    vec.resize(10, 0);
+                    assert_eq!(vec.len(), 10);
+                    assert!(vec.capacity() >= 5);
+                });
+            }
+        };
+        let expected = quote! {
+            #[test]
+            fn case_async() {
+                async fn __inner__() {
+                    let mut vec = vec![0usize; 5];
+                    assert_eq!(vec.len(), 5);
+                    assert!(vec.capacity() >= 5);
+
+                    {
+                        static SECTION: rye::_internal::SectionId = rye::_internal::SectionId::SubSection {
+                            name: "resizing bigger changes size and capacity",
+                            file: file!(),
+                            line: line!(),
+                            column: column!(),
+                        };
+
+                        if let Some(section) = rye::_internal::new_section(&SECTION) {
+                            let _guard = rye::_internal::Guard::set(Some(Box::new(section)));
+
+                            {
+                                vec.resize(10, 0);
+                                assert_eq!(vec.len(), 10);
+                                assert!(vec.capacity() >= 5);
+                            }
+                        }
+                    }
+                }
+
+                block_on(async {
+                    let mut test_case = rye::TestCase::new();
+                    while !test_case.completed() {
+                        test_case.run_async(__inner__()).await;
+                    }
+                });
+            }
+        };
+
+        let output = test_case(args, item).unwrap();
+        assert_eq!(output.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_async_with_args() {
+        let args = quote!(block_on = "path::to::custom_block_on");
+        let item = quote! {
+            async fn case_async() {
+                let mut vec = vec![0usize; 5];
+                assert_eq!(vec.len(), 5);
+                assert!(vec.capacity() >= 5);
+
+                section!("resizing bigger changes size and capacity", {
+                    vec.resize(10, 0);
+                    assert_eq!(vec.len(), 10);
+                    assert!(vec.capacity() >= 5);
+                });
+            }
+        };
+        let expected = quote! {
+            #[test]
+            fn case_async() {
+                async fn __inner__() {
+                    let mut vec = vec![0usize; 5];
+                    assert_eq!(vec.len(), 5);
+                    assert!(vec.capacity() >= 5);
+
+                    {
+                        static SECTION: rye::_internal::SectionId = rye::_internal::SectionId::SubSection {
+                            name: "resizing bigger changes size and capacity",
+                            file: file!(),
+                            line: line!(),
+                            column: column!(),
+                        };
+
+                        if let Some(section) = rye::_internal::new_section(&SECTION) {
+                            let _guard = rye::_internal::Guard::set(Some(Box::new(section)));
+
+                            {
+                                vec.resize(10, 0);
+                                assert_eq!(vec.len(), 10);
+                                assert!(vec.capacity() >= 5);
+                            }
+                        }
+                    }
+                }
+
+                path::to::custom_block_on(async {
+                    let mut test_case = rye::TestCase::new();
+                    while !test_case.completed() {
+                        test_case.run_async(__inner__()).await;
+                    }
+                });
+            }
+        };
+
+        let output = test_case(args, item).unwrap();
+        assert_eq!(output.to_string(), expected.to_string());
+    }
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,87 +1,15 @@
 extern crate proc_macro;
 
+mod args;
+mod expand;
+mod generate;
+mod imp;
+
 use proc_macro::TokenStream;
-use quote::quote;
-
-struct Args {
-    values: Vec<syn::MetaNameValue>,
-}
-
-mod args {
-    use syn::{
-        parse::{Parse, ParseStream, Result},
-        punctuated::Punctuated,
-    };
-
-    impl Parse for super::Args {
-        fn parse(input: ParseStream) -> Result<Self> {
-            let values = Punctuated::<syn::MetaNameValue, syn::Token![,]>::parse_terminated(input)?;
-            Ok(Self {
-                values: values.into_iter().collect(),
-            })
-        }
-    }
-}
 
 #[proc_macro_attribute]
 pub fn test_case(args: TokenStream, item: TokenStream) -> TokenStream {
-    let args = syn::parse_macro_input!(args as Args);
-    let item = syn::parse_macro_input!(item as syn::ItemFn);
-
-    let vis = &item.vis;
-    let fn_token = &item.sig.fn_token;
-    let ident = &item.sig.ident;
-    let output = &item.sig.output;
-    let block = &*item.block;
-
-    let test_attr: syn::Attribute = syn::parse_quote!(#[test]);
-    let attrs = Some(&test_attr).into_iter().chain(&item.attrs);
-
-    let body = match item.sig.asyncness {
-        Some(ref async_token) => {
-            let block_on: syn::Path = match args
-                .values
-                .iter()
-                .find(|value| value.path.is_ident("block_on"))
-            {
-                Some(value) => match &value.lit {
-                    syn::Lit::Str(lit_str) => match lit_str.parse() {
-                        Ok(path) => path,
-                        Err(err) => return err.to_compile_error().into(),
-                    },
-                    lit => {
-                        use syn::spanned::Spanned;
-                        let span = lit.span();
-                        return quote::quote_spanned!(span => const _: () = compile_error!("should be a string literal");)
-                            .into();
-                    }
-                },
-                None => syn::parse_quote!(block_on),
-            };
-
-            quote! {
-                #async_token #fn_token __inner__() #output  { #block }
-                #block_on(async {
-                    let mut test_case = rye::TestCase::new();
-                    while !test_case.completed() {
-                        test_case.run_async(__inner__()).await;
-                    }
-                });
-            }
-        }
-        None => quote! {
-            #fn_token __inner__() #output { #block }
-            let mut test_case = rye::TestCase::new();
-            while !test_case.completed() {
-                test_case.run(__inner__);
-            }
-        },
-    };
-
-    TokenStream::from(quote! {
-        #(#attrs)*
-        #vis #fn_token #ident () {
-            #body
-        }
-    })
+    crate::imp::test_case(args.into(), item.into())
+        .map(Into::into)
+        .unwrap_or_else(|err| err.to_compile_error().into())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,16 +25,7 @@ pub mod _internal {
 /// Declare a section in the test case.
 #[macro_export]
 macro_rules! section {
-    ($name:expr, $body:block) => {{
-        static SECTION: $crate::_internal::SectionId = $crate::_internal::SectionId::SubSection {
-            name: $name,
-            file: file!(),
-            line: line!(),
-            column: column!(),
-        };
-        if let Some(section) = $crate::_internal::new_section(&SECTION) {
-            let _guard = $crate::_internal::Guard::set(Some(Box::new(section)));
-            $body
-        }
-    }};
+    ($($t:tt)*) => {
+        compile_error!("section!() cannot be used outside of #[test_case]")
+    };
 }

--- a/tests/macro.rs
+++ b/tests/macro.rs
@@ -5,11 +5,33 @@ fn case_sync() {
     assert_eq!(vec.len(), 5);
     assert!(vec.capacity() >= 5);
 
-    rye::section!("resizing bigger changes size and capacity", {
+    section!("resizing bigger changes size and capacity", {
         vec.resize(10, 0);
 
         assert_eq!(vec.len(), 10);
         assert!(vec.capacity() >= 5);
+    });
+}
+
+#[rye::test_case]
+fn nested() {
+    let mut vec = vec![0usize; 5];
+
+    assert_eq!(vec.len(), 5);
+    assert!(vec.capacity() >= 5);
+
+    section!("resizing bigger changes size and capacity", {
+        vec.resize(10, 0);
+
+        assert_eq!(vec.len(), 10);
+        assert!(vec.capacity() >= 10);
+
+        section!("shrinking smaller does not changes capacity", {
+            vec.resize(0, 0);
+
+            assert_eq!(vec.len(), 0);
+            assert!(vec.capacity() >= 10);
+        });
     });
 }
 
@@ -20,7 +42,7 @@ async fn case_async() {
     assert_eq!(vec.len(), 5);
     assert!(vec.capacity() >= 5);
 
-    rye::section!("resizing bigger changes size and capacity", {
+    section!("resizing bigger changes size and capacity", {
         vec.resize(10, 0);
 
         assert_eq!(vec.len(), 10);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,20 @@
 use rye::TestCase;
 
+macro_rules! section {
+    ($name:expr, $body:block) => {{
+        static SECTION: rye::_internal::SectionId = rye::_internal::SectionId::SubSection {
+            name: $name,
+            file: file!(),
+            line: line!(),
+            column: column!(),
+        };
+        if let Some(section) = rye::_internal::new_section(&SECTION) {
+            let _guard = rye::_internal::Guard::set(Some(Box::new(section)));
+            $body
+        }
+    }};
+}
+
 #[test]
 fn no_section() {
     let mut history = vec![];
@@ -20,7 +35,7 @@ fn one_section() {
         test_case.run(|| {
             history.push("setup");
 
-            rye::section!("section1", {
+            section!("section1", {
                 history.push("section1");
             });
 
@@ -38,11 +53,11 @@ fn multi_section() {
         test_case.run(|| {
             history.push("setup");
 
-            rye::section!("section1", {
+            section!("section1", {
                 history.push("section1");
             });
 
-            rye::section!("section2", {
+            section!("section2", {
                 history.push("section2");
             });
 
@@ -68,14 +83,14 @@ fn nested_section() {
         test_case.run(|| {
             history.push("setup");
 
-            rye::section!("section1", {
+            section!("section1", {
                 history.push("section1:setup");
 
-                rye::section!("section2", {
+                section!("section2", {
                     history.push("section2");
                 });
 
-                rye::section!("section3", {
+                section!("section3", {
                     history.push("section3");
                 });
 
@@ -84,7 +99,7 @@ fn nested_section() {
 
             history.push("test");
 
-            rye::section!("section4", {
+            section!("section4", {
                 history.push("section4");
             });
 
@@ -129,16 +144,16 @@ fn smoke_async() {
             history.push("setup");
             async {}.pending_once().await;
 
-            rye::section!("section1", {
+            section!("section1", {
                 history.push("section1:setup");
                 async {}.pending_once().await;
 
-                rye::section!("section2", {
+                section!("section2", {
                     async {}.pending_once().await;
                     history.push("section2");
                 });
 
-                rye::section!("section3", {
+                section!("section3", {
                     async {}.pending_once().await;
                     history.push("section3");
                 });
@@ -150,7 +165,7 @@ fn smoke_async() {
             history.push("test");
             async {}.pending_once().await;
 
-            rye::section!("section4", {
+            section!("section4", {
                 async {}.pending_once().await;
                 history.push("section4");
             });


### PR DESCRIPTION
The motivation of this patch is to be able to utilize information from the test case when expanding `section!()`  macros.